### PR TITLE
feat: add some basic TTS functionality

### DIFF
--- a/src/show-dogs.tsx
+++ b/src/show-dogs.tsx
@@ -1,10 +1,42 @@
-import { Detail, ActionPanel, Action } from "@raycast/api";
+import { Detail, ActionPanel, Action, getPreferenceValues } from "@raycast/api";
 import { useState, useEffect } from "react";
 import fetch from "node-fetch";
+import { execSync } from "child_process";
 
 interface DogResponse {
   message: string;
   status: string;
+}
+
+const PHRASES = [
+  "Look at this adorable",
+  "Here's a beautiful",
+  "Check out this cute",
+  "Aww, it's a lovely",
+  "Meet this wonderful",
+];
+
+function getRandomPhrase(): string {
+  return PHRASES[Math.floor(Math.random() * PHRASES.length)];
+}
+
+function extractBreedFromUrl(url: string): string {
+  // URL format: https://images.dog.ceo/breeds/hound-afghan/n02088094_1003.jpg
+  try {
+    const breedPart = url.split('/breeds/')[1].split('/')[0];
+    // Convert "hound-afghan" to "afghan hound"
+    return breedPart.split('-').reverse().join(' ');
+  } catch {
+    return "dog";
+  }
+}
+
+function speak(text: string) {
+  try {
+    execSync(`say "${text}"`);
+  } catch (error) {
+    console.error('Error with text-to-speech:', error);
+  }
 }
 
 export default function Command() {
@@ -24,6 +56,12 @@ export default function Command() {
       const data = await response.json() as DogResponse;
       setDogImage(data.message);
       setError(null);
+
+      // Speak the breed name with a random phrase
+      const breed = extractBreedFromUrl(data.message);
+      const phrase = getRandomPhrase();
+      speak(`${phrase} ${breed}`);
+
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : 'An unknown error occurred';
       console.error('Error fetching dog:', e);
@@ -50,8 +88,9 @@ export default function Command() {
     );
   }
 
+  const breed = dogImage ? extractBreedFromUrl(dogImage) : '';
   const markdown = dogImage
-    ? `# Random Dog\n\n![Dog](${dogImage})\n\n_Press ⌘+R to see another dog!_`
+    ? `# ${breed.charAt(0).toUpperCase() + breed.slice(1)}\n\n![Dog](${dogImage})\n\n_Press ⌘+R to see another dog!_\n\n_Press ⌘+S to hear the breed name again_`
     : "# Loading...";
 
   return (
@@ -60,7 +99,16 @@ export default function Command() {
       isLoading={isLoading}
       actions={
         <ActionPanel>
-          <Action title="New Dog" onAction={fetchDog} shortcut={{ modifiers: ["cmd"], key: "r" }} />
+          <Action 
+            title="New Dog" 
+            onAction={fetchDog} 
+            shortcut={{ modifiers: ["cmd"], key: "r" }} 
+          />
+          <Action
+            title="Speak Breed"
+            onAction={() => speak(`This is a ${extractBreedFromUrl(dogImage || '')}`)}
+            shortcut={{ modifiers: ["cmd"], key: "s" }}
+          />
         </ActionPanel>
       }
     />


### PR DESCRIPTION
### TL;DR
Added text-to-speech functionality and breed name extraction to the dog viewer extension.

### What changed?
- Added automatic text-to-speech announcements when displaying new dog images
- Extracts breed names from image URLs and displays them as titles
- Implemented random friendly phrases for voice announcements
- Added a new "Speak Breed" command (⌘+S) to repeat the breed name

### How to test?
1. Open the extension and wait for a dog image to load
2. Verify that you hear a random phrase with the breed name
3. Press ⌘+R to load a new dog and hear a new announcement
4. Press ⌘+S to hear the breed name again
5. Verify that the breed name appears as the title above the image

### Why make this change?
This enhancement makes the extension more accessible and engaging by adding audio feedback and better breed identification. The random friendly phrases add personality to the experience, while the breed name extraction provides more context about each dog being displayed.