### PR TITLE
feat: allow voice selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,42 @@
       "required": true,
       "title": "OpenAI API Key",
       "description": "Your OpenAI API key for text-to-speech functionality"
+    },
+    {
+      "name": "voice",
+      "type": "dropdown",
+      "required": true,
+      "title": "Voice",
+      "description": "Select the voice to use for text-to-speech. Open this extension then use CMD+T to test the currently selected voice.",
+      "default": "alloy",
+      "data": [
+        { "title": "Alloy - Neutral, versatile voice", "value": "alloy" },
+        { "title": "Echo - Deep, warm male voice", "value": "echo" },
+        { "title": "Fable - British-accented storyteller", "value": "fable" },
+        { "title": "Onyx - Deep, authoritative male voice", "value": "onyx" },
+        { "title": "Nova - Feminine, energetic voice", "value": "nova" },
+        { "title": "Shimmer - Clear, youthful female voice", "value": "shimmer" }
+      ]
+    },
+    {
+      "name": "model",
+      "type": "dropdown",
+      "required": true,
+      "title": "TTS Model",
+      "description": "Select the TTS model to use",
+      "default": "tts-1",
+      "data": [
+        { "title": "TTS-1", "value": "tts-1" },
+        { "title": "TTS-1-HD", "value": "tts-1-hd" }
+      ]
+    },
+    {
+      "name": "speed",
+      "type": "textfield",
+      "required": false,
+      "title": "Speech Speed",
+      "description": "Speed of speech (0.25 to 4.0)",
+      "default": "1.0"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
### TL;DR
Added voice customization options and testing capabilities to the text-to-speech functionality.

### What changed?
- Added new preferences for voice selection, TTS model, and speech speed
- Implemented voice testing feature with sample phrases for each voice type
- Added speed control (0.25 to 4.0) for speech playback
- Included six different voice options: Alloy, Echo, Fable, Onyx, Nova, and Shimmer
- Added a new "Test Current Voice" action with CMD+T shortcut

### How to test?
1. Open the extension preferences and select a voice from the dropdown
2. Adjust the speech speed if desired (default is 1.0)
3. Choose between TTS-1 and TTS-1-HD models
4. Use CMD+T to test the currently selected voice with its sample phrase
5. Use the main functionality to verify the new voice settings with dog breeds

### Why make this change?
To provide users with more control over the text-to-speech experience by allowing them to customize the voice, speed, and quality of the audio output. The addition of voice testing helps users quickly preview and select their preferred voice option.