### PR TITLE
fix: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Show Dogs - A Raycast Extension Example
 
-This is a simple experimental project created to learn Raycast extension development. It displays random dog images from the [Dog CEO API](https://dog.ceo/dog-api/) and serves as a basic example of how to create Raycast extensions.
+This is a simple experimental project created to learn Raycast extension development. It displays random dog images from the [Dog CEO API](https://dog.ceo/dog-api/) with voice search and text-to-speech capabilities.
 
 ## Learning Purpose
 
@@ -10,11 +10,17 @@ This extension demonstrates several fundamental concepts of Raycast extension de
 - Handling loading states and errors
 - Using Raycast's UI components (Detail, ActionPanel, Action)
 - Implementing keyboard shortcuts
+- Voice recognition and text-to-speech integration
+- Audio recording and playback
+- OpenAI API integration
 
 ## Features
 
 - 🐕 Shows a random dog image each time you open the extension
 - 🔄 Press ⌘+R to fetch a new random dog image
+- 🎤 Press ⌘+V to search for specific breeds using voice commands
+- 🗣️ Press ⌘+S to hear the breed name spoken aloud
+- 🎯 Press ⌘+T to test your selected text-to-speech voice
 - 🖼️ High-quality dog images from various breeds
 
 ## Installation
@@ -26,7 +32,12 @@ This is a development/learning project. To experiment with it:
    ```bash
    npm install
    ```
-3. Run the development server:
+3. Install Sox (required for voice recording):
+   ```bash
+   brew install sox
+   ```
+4. Set up your OpenAI API key in Raycast preferences
+5. Run the development server:
    ```bash
    npm run dev
    ```
@@ -36,7 +47,11 @@ This is a development/learning project. To experiment with it:
 1. Open Raycast
 2. Search for "Show Dogs"
 3. Press Enter to see a random dog
-4. Press ⌘+R to see a new dog image
+4. Use keyboard shortcuts:
+   - ⌘+R: Show new random dog
+   - ⌘+V: Start voice search
+   - ⌘+S: Speak breed name
+   - ⌘+T: Test current voice
 
 ## Development Notes
 
@@ -44,6 +59,10 @@ This project uses:
 - React for UI components
 - TypeScript for type safety
 - Raycast's Extension API
+- Dog CEO API for dog images
+- OpenAI's Whisper API for speech-to-text
+- OpenAI's TTS API for text-to-speech
+- Sox for audio recording
 - Native fetch API for network requests
 
 Feel free to use this as a reference for building your own Raycast extensions!
@@ -52,6 +71,7 @@ Feel free to use this as a reference for building your own Raycast extensions!
 
 - Dog images provided by the [Dog CEO API](https://dog.ceo/dog-api/)
 - Built with [Raycast Extensions API](https://developers.raycast.com)
+- Voice features powered by [OpenAI](https://openai.com)
 
 ## License
 


### PR DESCRIPTION
### TL;DR
Added voice search and text-to-speech capabilities to the Show Dogs Raycast extension.

### What changed?
- Added voice command functionality for breed searches (⌘+V)
- Integrated text-to-speech for breed name pronunciation (⌘+S)
- Added voice testing feature (⌘+T)
- Integrated OpenAI's Whisper API for speech-to-text conversion
- Integrated OpenAI's TTS API for text-to-speech functionality
- Added Sox dependency for audio recording capabilities

### How to test?
1. Install Sox using `brew install sox`
2. Configure OpenAI API key in Raycast preferences
3. Launch the Show Dogs extension
4. Test new keyboard shortcuts:
   - ⌘+V to search breeds using voice commands
   - ⌘+S to hear breed names spoken
   - ⌘+T to test the selected text-to-speech voice

### Why make this change?
To enhance the user experience by adding voice interaction capabilities, making the extension more accessible and interactive while demonstrating integration with advanced APIs like OpenAI's Whisper and TTS.